### PR TITLE
Add safe array access.

### DIFF
--- a/Sources/Array+Sweetness.swift
+++ b/Sources/Array+Sweetness.swift
@@ -5,3 +5,9 @@ public extension Array {
         return self[Int(arc4random_uniform(UInt32(self.count)))] as Element
     }
 }
+
+extension Collection where Indices.Iterator.Element == Index {
+    subscript (safe index: Index) -> Generator.Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}


### PR DESCRIPTION
## Why?

Because Swift does not provide a safe way to access an object from a collection I added this extension to `Collection` that either returns an object or returns nil.

## Usage:

```
if let item = items[safe: 3] {
    // use item here safely
}
```