### PR TITLE
Added Range<->NSRange conversion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ We include a simple JSON to String serialiser that guarantees the order of dicti
 ```swift
 let hashableString = OrderedSerializer.string(from: jsonPayload)
 ```
+
+### String range conversion.
+To avoid having to do constant casts to `String` or `NSString` to get the range type you need, we've added two simple methods to convert between them:g
+
+```swift
+// from Range<String.Index> to NSRange
+let range = string.range(of: "substring")
+let nsRange = range.nsRange(on: string)
+
+// from NSRange to Range<String.Index>
+let range = nsRange.range(on: string as NSString)
+```
+
 ### Base64 with or without padding
 Sometimes you need to deal with base64 strings without the padding.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ let hashableString = OrderedSerializer.string(from: jsonPayload)
 ```
 
 ### String range conversion.
-To avoid having to do constant casts to `String` or `NSString` to get the range type you need, we've added two simple methods to convert between them:g
+To avoid having to do constant casts to `String` or `NSString` to get the range type you need, we've added two simple methods to convert between them:
 
 ```swift
 // from Range<String.Index> to NSRange

--- a/Sources/String+Sweetness.swift
+++ b/Sources/String+Sweetness.swift
@@ -10,8 +10,9 @@ public extension Range where Bound: _StringIndex {
     /// - Parameter string: string where ranges will be applied. Necessary to ensure that multi-byte code-points are treated properly.
     /// - Returns: the NSRange representation of a Range<String.Index> for the given string.
     public func nsRange(on string: String) -> NSRange {
-        let lowerBound = self.lowerBound as! String.Index
-        let upperBound = self.upperBound as! String.Index
+        guard let lowerBound = self.lowerBound as? String.Index, let upperBound = self.upperBound as? String.Index else {
+            fatalError("Could not cast range bounds as String.Index.")
+        }
 
         // always use utf16, as it's the internal representation of NSStrings, to ensure that clusters are counted correctly
         let location = string.utf16.distance(from: string.utf16.startIndex, to: lowerBound)

--- a/Sources/String+Sweetness.swift
+++ b/Sources/String+Sweetness.swift
@@ -1,5 +1,34 @@
 import Foundation
 
+public protocol _StringIndex {}
+extension String.Index: _StringIndex {}
+
+public extension Range where Bound: _StringIndex {
+    /// Translates a Range<String.Index> into a correct NSRange for use with NSStrings.
+    /// Should help avoind all the `as String` or `as NSString` casting.
+    ///
+    /// - Parameter string: string where ranges will be applied. Necessary to ensure that multi-byte code-points are treated properly.
+    /// - Returns: the NSRange representation of a Range<String.Index> for the given string.
+    public func nsRange(on string: String) -> NSRange {
+        let lowerBound = self.lowerBound as! String.Index
+        let upperBound = self.upperBound as! String.Index
+
+        // always use utf16, as it's the internal representation of NSStrings, to ensure that clusters are counted correctly
+        let location = string.utf16.distance(from: string.utf16.startIndex, to: lowerBound)
+        let length = string.utf16.distance(from: lowerBound, to: upperBound)
+
+        return NSRange(location: location, length: length)
+    }
+}
+
+public extension NSRange {
+    public func range(on string: NSString) -> Range<String.Index>? {
+        let substring = string.substring(with: self)
+
+        return (string as String).range(of: substring)
+    }
+}
+
 public extension String {
     public var paddedForBase64: String {
         let length = self.decomposedStringWithCanonicalMapping.count

--- a/Sources/String+Sweetness.swift
+++ b/Sources/String+Sweetness.swift
@@ -51,10 +51,10 @@ public extension String {
         }
     }
 
-    public func substring(with range: NSRange) -> Substring? {
-        guard let r = range.range(on: self as NSString) else { return nil }
+    public func substring(with nsRange: NSRange) -> Substring? {
+        guard let range = nsRange.range(on: self as NSString) else { return nil }
 
-        return self[r]
+        return self[range]
     }
 
     public func nsRange(of string: String) -> NSRange {

--- a/Sources/String+Sweetness.swift
+++ b/Sources/String+Sweetness.swift
@@ -28,6 +28,12 @@ public extension NSRange {
 
         return (string as String).range(of: substring)
     }
+
+    public func range(on string: String) -> Range<String.Index>? {
+        guard let substring = string.substring(with: self) else { fatalError("Range out of bounds for string.") }
+
+        return (string).range(of: substring)
+    }
 }
 
 public extension String {
@@ -43,5 +49,15 @@ public extension String {
         } else {
             return self
         }
+    }
+
+    public func substring(with range: NSRange) -> Substring? {
+        guard let r = range.range(on: self as NSString) else { return nil }
+
+        return self[r]
+    }
+
+    public func nsRange(of string: String) -> NSRange {
+        return (self as NSString).range(of: string)
     }
 }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -141,7 +141,7 @@ class Tests: XCTestCase {
 
         let nsRange = string.range(of: expected)
         guard let range = nsRange.range(on: string) else {
-            XCTAssertFalse(true)
+            XCTAssertTrue(false, "Could not get range of substring.")
             return
         }
 
@@ -156,7 +156,7 @@ class Tests: XCTestCase {
 
         let nsRange = string.range(of: expected)
         guard let range = nsRange.range(on: string) else {
-            XCTAssertFalse(true)
+            XCTAssertTrue(false, "Could not get range of substring.")
             return
         }
 
@@ -171,7 +171,7 @@ class Tests: XCTestCase {
 
         let nsRange = string.range(of: expected)
         guard let range = nsRange.range(on: string) else {
-            XCTAssertFalse(true)
+            XCTAssertTrue(false, "Could not get range of substring.")
             return
         }
 
@@ -186,7 +186,7 @@ class Tests: XCTestCase {
 
         let nsRange = string.range(of: expected)
         guard let range = nsRange.range(on: string) else {
-            XCTAssertFalse(true)
+            XCTAssertTrue(false, "Could not get range of substring.")
             return
         }
 
@@ -198,7 +198,10 @@ class Tests: XCTestCase {
     func testRangesFromString() {
         let string = "This is a *test* string. 🧐 👩‍👩‍👧 Added some emoji clusters *here*."
         let nsRange = string.nsRange(of: "*here*")
-        let range = string.range(of: "*here*")!
+        guard let range = string.range(of: "*here*") else {
+            XCTAssertTrue(false, "Could not get range of substring.")
+            return
+        }
 
         XCTAssertEqual(range.nsRange(on: string), nsRange)
         XCTAssertEqual(nsRange.range(on: string as NSString), range)

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -86,4 +86,116 @@ class Tests: XCTestCase {
         
         XCTAssertEqual(description, "https://simple.org\n[\"Content-Type\": \"application/json\"]\n{\"parameter1\":\"value\"}")
     }
+
+    func testStringRangeConversionIncludesEmojiCluster() {
+        let string = "This is a *test* string. 🧐 👩‍👩‍👧 Added some emoji clusters *here*."
+        _ = {
+            let expected = "*here*"
+
+            let range = string.range(of: expected)!
+            let nsRange = range.nsRange(on: string)
+
+            let substring = (string as NSString).substring(with: nsRange)
+
+            XCTAssertEqual(substring, expected)
+        }()
+
+        _ = {
+            let expected = "*test*"
+
+            let range = string.range(of: expected)!
+            let nsRange = range.nsRange(on: string)
+
+            let substring = (string as NSString).substring(with: nsRange)
+
+            XCTAssertEqual(substring, expected)
+        }()
+    }
+
+    func testStringRangeConversionsIncludesEmoji() {
+        let string = "🤔 This is a *test* string."
+        let expected = "*test*"
+
+        let range = string.range(of: expected)!
+        let nsRange = range.nsRange(on: string)
+
+        let substring = (string as NSString).substring(with: nsRange)
+
+        XCTAssertEqual(substring, expected)
+    }
+
+    func testStringRangeConversionsPlainString() {
+        let string = "This is a *test* string."
+        let expected = "*test*"
+
+        let range = string.range(of: expected)!
+        let nsRange = range.nsRange(on: string)
+
+        let substring = (string as NSString).substring(with: nsRange)
+
+        XCTAssertEqual(substring, expected)
+    }
+
+    func testStringNSRangeConversionIncludesEmojiCluster() {
+        let string = NSString(string: "This is a *test* string. 🧐 👩‍👩‍👧 Added some emoji clusters *here*.")
+
+        _ = {
+            let expected = "*here*"
+
+            let nsRange = string.range(of: expected)
+            guard let range = nsRange.range(on: string) else {
+                XCTAssertFalse(true)
+                return
+            }
+
+            let substring = String((string as String)[range])
+
+            XCTAssertEqual(substring, expected)
+        }()
+
+        _ = {
+            let expected = "*test*"
+
+            let nsRange = string.range(of: expected)
+            guard let range = nsRange.range(on: string) else {
+                XCTAssertFalse(true)
+                return
+            }
+
+            let substring = String((string as String)[range])
+
+            XCTAssertEqual(substring, expected)
+        }()
+    }
+
+    func testStringNSRangeConversionsIncludesEmoji() {
+        let string = NSString(string: "🤔 This is a *test* string.")
+        let expected = "*test*"
+
+        let nsRange = string.range(of: expected)
+        guard let range = nsRange.range(on: string) else {
+            XCTAssertFalse(true)
+            return
+        }
+
+        let substring = String((string as String)[range])
+
+        XCTAssertEqual(substring, expected)
+    }
+
+    func testStringNSRangeConversionsPlainString() {
+        let string = NSString(string: "This is a *test* string.")
+        let expected = "*test*"
+
+        let nsRange = string.range(of: expected)
+        guard let range = nsRange.range(on: string) else {
+            XCTAssertFalse(true)
+            return
+        }
+
+        let substring = String((string as String)[range])
+
+        XCTAssertEqual(substring, expected)
+    }
+
 }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import SweetFoundation
+import XCTest
 
 class Tests: XCTestCase {
 
@@ -77,42 +77,41 @@ class Tests: XCTestCase {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         let parameters: [String: Any] = [
-                "parameter1": "value"
+            "parameter1": "value"
         ]
 
         request.httpBody = try! JSONSerialization.data(withJSONObject: parameters, options: [])
-        
+
         let description = request.debugLog()
-        
+
         XCTAssertEqual(description, "https://simple.org\n[\"Content-Type\": \"application/json\"]\n{\"parameter1\":\"value\"}")
     }
 
-    func testStringRangeConversionIncludesEmojiCluster() {
+    func testStringRangeConversionBeforeEmojiCluster() {
         let string = "This is a *test* string. 🧐 👩‍👩‍👧 Added some emoji clusters *here*."
-        _ = {
-            let expected = "*here*"
+        let expected = "*test*"
 
-            let range = string.range(of: expected)!
-            let nsRange = range.nsRange(on: string)
+        let range = string.range(of: expected)!
+        let nsRange = range.nsRange(on: string)
 
-            let substring = (string as NSString).substring(with: nsRange)
+        let substring = (string as NSString).substring(with: nsRange)
 
-            XCTAssertEqual(substring, expected)
-        }()
-
-        _ = {
-            let expected = "*test*"
-
-            let range = string.range(of: expected)!
-            let nsRange = range.nsRange(on: string)
-
-            let substring = (string as NSString).substring(with: nsRange)
-
-            XCTAssertEqual(substring, expected)
-        }()
+        XCTAssertEqual(substring, expected)
     }
 
-    func testStringRangeConversionsIncludesEmoji() {
+    func testStringRangeConversionAfterEmojiCluster() {
+        let string = "This is a *test* string. 🧐 👩‍👩‍👧 Added some emoji clusters *here*."
+        let expected = "*here*"
+
+        let range = string.range(of: expected)!
+        let nsRange = range.nsRange(on: string)
+
+        let substring = (string as NSString).substring(with: nsRange)
+
+        XCTAssertEqual(substring, expected)
+    }
+
+    func testStringRangeConversionsIncludesNonClusterEmoji() {
         let string = "🤔 This is a *test* string."
         let expected = "*test*"
 
@@ -136,39 +135,37 @@ class Tests: XCTestCase {
         XCTAssertEqual(substring, expected)
     }
 
-    func testStringNSRangeConversionIncludesEmojiCluster() {
+    func testStringNSRangeConversionBeforeEmojiCluster() {
         let string = NSString(string: "This is a *test* string. 🧐 👩‍👩‍👧 Added some emoji clusters *here*.")
+        let expected = "*test*"
 
-        _ = {
-            let expected = "*here*"
+        let nsRange = string.range(of: expected)
+        guard let range = nsRange.range(on: string) else {
+            XCTAssertFalse(true)
+            return
+        }
 
-            let nsRange = string.range(of: expected)
-            guard let range = nsRange.range(on: string) else {
-                XCTAssertFalse(true)
-                return
-            }
+        let substring = String((string as String)[range])
 
-            let substring = String((string as String)[range])
-
-            XCTAssertEqual(substring, expected)
-        }()
-
-        _ = {
-            let expected = "*test*"
-
-            let nsRange = string.range(of: expected)
-            guard let range = nsRange.range(on: string) else {
-                XCTAssertFalse(true)
-                return
-            }
-
-            let substring = String((string as String)[range])
-
-            XCTAssertEqual(substring, expected)
-        }()
+        XCTAssertEqual(substring, expected)
     }
 
-    func testStringNSRangeConversionsIncludesEmoji() {
+    func testStringNSRangeConversionAfterEmojiCluster() {
+        let string = NSString(string: "This is a *test* string. 🧐 👩‍👩‍👧 Added some emoji clusters *here*.")
+        let expected = "*here*"
+
+        let nsRange = string.range(of: expected)
+        guard let range = nsRange.range(on: string) else {
+            XCTAssertFalse(true)
+            return
+        }
+
+        let substring = String((string as String)[range])
+
+        XCTAssertEqual(substring, expected)
+    }
+
+    func testStringNSRangeConversionsIncludesNonClusterEmoji() {
         let string = NSString(string: "🤔 This is a *test* string.")
         let expected = "*test*"
 
@@ -197,5 +194,4 @@ class Tests: XCTestCase {
 
         XCTAssertEqual(substring, expected)
     }
-
 }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -194,4 +194,22 @@ class Tests: XCTestCase {
 
         XCTAssertEqual(substring, expected)
     }
+
+    func testRangesFromString() {
+        let string = "This is a *test* string. 🧐 👩‍👩‍👧 Added some emoji clusters *here*."
+        let nsRange = string.nsRange(of: "*here*")
+        let range = string.range(of: "*here*")!
+
+        XCTAssertEqual(range.nsRange(on: string), nsRange)
+        XCTAssertEqual(nsRange.range(on: string as NSString), range)
+    }
+
+    func testNSRangeSubstring() {
+        let string = "This is a *test* string. 🧐 👩‍👩‍👧 Added some emoji clusters *here*."
+        let range = NSRange(location: 63, length: 6)
+
+        let substring = string.substring(with: range)
+
+        XCTAssertEqual(substring, "*here*")
+    }
 }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -141,7 +141,7 @@ class Tests: XCTestCase {
 
         let nsRange = string.range(of: expected)
         guard let range = nsRange.range(on: string) else {
-            XCTAssertTrue(false, "Could not get range of substring.")
+            XCTFail("Could not get range of substring.")
             return
         }
 
@@ -156,7 +156,7 @@ class Tests: XCTestCase {
 
         let nsRange = string.range(of: expected)
         guard let range = nsRange.range(on: string) else {
-            XCTAssertTrue(false, "Could not get range of substring.")
+            XCTFail("Could not get range of substring.")
             return
         }
 
@@ -171,7 +171,7 @@ class Tests: XCTestCase {
 
         let nsRange = string.range(of: expected)
         guard let range = nsRange.range(on: string) else {
-            XCTAssertTrue(false, "Could not get range of substring.")
+            XCTFail("Could not get range of substring.")
             return
         }
 
@@ -186,7 +186,7 @@ class Tests: XCTestCase {
 
         let nsRange = string.range(of: expected)
         guard let range = nsRange.range(on: string) else {
-            XCTAssertTrue(false, "Could not get range of substring.")
+            XCTFail("Could not get range of substring.")
             return
         }
 
@@ -199,7 +199,7 @@ class Tests: XCTestCase {
         let string = "This is a *test* string. 🧐 👩‍👩‍👧 Added some emoji clusters *here*."
         let nsRange = string.nsRange(of: "*here*")
         guard let range = string.range(of: "*here*") else {
-            XCTAssertTrue(false, "Could not get range of substring.")
+            XCTFail("Could not get range of substring.")
             return
         }
 


### PR DESCRIPTION
Added the ability to safely convert between `Range<String.Index>` and `NSRange`. To ensure safety, we need to have access to the `String` as well.

We use the `UTF16` view, to keep it consistent between systems and between `String` and `NSString` regardless of content (with or without clusters, such as complex emoji or CJK scripts.