### PR TITLE
Add KeyPath predicate support for the `IN` operator.

### DIFF
--- a/Sources/NSPredicate+Sweetness.swift
+++ b/Sources/NSPredicate+Sweetness.swift
@@ -51,6 +51,7 @@ extension NSPredicate {
     
     // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Predicates/Articles/pSyntax.html
     // The following operators get their own factory initializers:
+    // - IN, since it takes an array or a set
     // - MATCHES, since it takes a regular expression.
     // - BETWEEN, since it takes multiple parameters.
     public enum PredicateOperator: String {
@@ -173,6 +174,38 @@ extension NSPredicate {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [
             greaterThanOrEqualToFirst,
             lessThanOrEqualToSecond
+        ])
+    }
+    
+    public static func isValue<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property>,
+                                                                   in array: [Property]) -> NSPredicate {
+        return NSPredicate(format: "%K IN %@", argumentArray: [
+            keyPath.toNSString,
+            array
+        ])
+    }
+    
+    public static func isValue<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property?>,
+                                                                   in array: [Property]) -> NSPredicate {
+        return NSPredicate(format: "%K IN %@", argumentArray: [
+            keyPath.toNSString,
+            array
+        ])
+    }
+    
+    public static func isValue<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property>,
+                                                                   in set: Set<Property>) -> NSPredicate {
+        return NSPredicate(format: "%K IN %@", argumentArray: [
+            keyPath.toNSString,
+            set
+        ])
+    }
+    
+    public static func isValue<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property?>,
+                                                                   in set: Set<Property>) -> NSPredicate {
+        return NSPredicate(format: "%K IN %@", argumentArray: [
+            keyPath.toNSString,
+            set
         ])
     }
 }

--- a/Sources/NSPredicate+Sweetness.swift
+++ b/Sources/NSPredicate+Sweetness.swift
@@ -92,11 +92,15 @@ extension NSPredicate {
                 value._object
             ])
     }
-        
+    
+    // MARK: - Matches
+    
+    private static let matchesFormat = "%K MATCHES %@"
+    
     public static func matches<Root, Property: ComparableProperty>(_ regex: NSRegularExpression,
                                                                    for keyPath: KeyPath<Root, Property>) -> NSPredicate {
         return NSPredicate(
-            format: "%K MATCHES %@",
+            format: self.matchesFormat,
             argumentArray: [
                 keyPath.toNSString,
                 regex.pattern
@@ -106,12 +110,16 @@ extension NSPredicate {
     public static func matches<Root, Property: ComparableProperty>(_ regex: NSRegularExpression,
                                                                    for keyPath: KeyPath<Root, Property?>) -> NSPredicate {
         return NSPredicate(
-            format: "%K MATCHES %@",
+            format: self.matchesFormat,
             argumentArray: [
                 keyPath.toNSString,
                 regex.pattern
             ])
     }
+    
+    // MARK: - Between
+    
+    private static let betweenFormat = "%K BETWEEN %@"
     
     public static func between<Root, Property: ComparableProperty>(_ firstValue: Property,
                                                                    and secondValue: Property,
@@ -121,7 +129,7 @@ extension NSPredicate {
             return self.floatCompatibleBetween(firstValue, and: secondValue, for: keyPath)
         } else {
             return NSPredicate(
-                format: "%K BETWEEN %@",
+                format: self.betweenFormat,
                 argumentArray: [
                     keyPath.toNSString,
                     [ firstValue._object, secondValue._object ]
@@ -137,7 +145,7 @@ extension NSPredicate {
             return self.floatCompatibleOptionalBetween(firstValue, and: secondValue, for: keyPath)
         } else {
             return NSPredicate(
-                format: "%K BETWEEN %@",
+                format: self.betweenFormat,
                 argumentArray: [
                     keyPath.toNSString,
                     [ firstValue._object, secondValue._object ]
@@ -158,7 +166,7 @@ extension NSPredicate {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [
             greaterThanOrEqualToFirst,
             lessThanOrEqualToSecond
-            ])
+        ])
     }
     
     private static func floatCompatibleOptionalBetween<Root, Property: ComparableProperty>(_ firstValue: Property,
@@ -177,35 +185,91 @@ extension NSPredicate {
         ])
     }
     
-    public static func isValue<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property>,
-                                                                   in array: [Property]) -> NSPredicate {
-        return NSPredicate(format: "%K IN %@", argumentArray: [
-            keyPath.toNSString,
-            array
-        ])
+    // MARK: - In
+    
+    private static let inFormat = "%K IN %@"
+    
+    public static func value<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property>,
+                                                                 isIn array: [Property]) -> NSPredicate {
+        return NSPredicate(
+            format: self.inFormat,
+            argumentArray: [
+                keyPath.toNSString,
+                array
+            ])
     }
     
-    public static func isValue<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property?>,
-                                                                   in array: [Property]) -> NSPredicate {
-        return NSPredicate(format: "%K IN %@", argumentArray: [
-            keyPath.toNSString,
-            array
-        ])
+    public static func value<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property?>,
+                                                                 isIn array: [Property]) -> NSPredicate {
+        return NSPredicate(
+            format: self.inFormat,
+            argumentArray: [
+                keyPath.toNSString,
+                array
+            ])
     }
     
-    public static func isValue<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property>,
-                                                                   in set: Set<Property>) -> NSPredicate {
-        return NSPredicate(format: "%K IN %@", argumentArray: [
-            keyPath.toNSString,
-            set
-        ])
+    public static func value<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property>,
+                                                                 isIn set: Set<Property>) -> NSPredicate {
+        return NSPredicate(
+            format: self.inFormat,
+            argumentArray: [
+                keyPath.toNSString,
+                set
+            ])
     }
     
-    public static func isValue<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property?>,
-                                                                   in set: Set<Property>) -> NSPredicate {
-        return NSPredicate(format: "%K IN %@", argumentArray: [
-            keyPath.toNSString,
-            set
-        ])
+    public static func value<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property?>,
+                                                                 isIn set: Set<Property>) -> NSPredicate {
+        return NSPredicate(
+            format: self.inFormat,
+            argumentArray: [
+                keyPath.toNSString,
+                set
+            ])
+    }
+    
+    // MARK: - Not in
+    
+    private static let notInFormat = "NOT (%K IN %@)"
+    
+    public static func value<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property>,
+                                                                 isNotIn array: [Property]) -> NSPredicate {
+        return NSPredicate(
+            format: self.notInFormat,
+            argumentArray: [
+                keyPath.toNSString,
+                array
+            ])
+    }
+    
+    public static func value<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property?>,
+                                                                 isNotIn array: [Property]) -> NSPredicate {
+        return NSPredicate(
+            format: self.notInFormat,
+            argumentArray: [
+                keyPath.toNSString,
+                array
+            ])
+    }
+    
+    public static func value<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property>,
+                                                                 isNotIn set: Set<Property>) -> NSPredicate {
+        return NSPredicate(
+            format: self.notInFormat,
+            argumentArray: [
+                keyPath.toNSString,
+                set
+            ])
+    }
+    
+    public static func value<Root, Property: ComparableProperty>(for keyPath: KeyPath<Root, Property?>,
+                                                                 isNotIn set: Set<Property>) -> NSPredicate {
+        return NSPredicate(
+            format: self.notInFormat,
+            argumentArray: [
+                keyPath.toNSString,
+                set
+            ])
     }
 }

--- a/SweetFoundation.podspec
+++ b/SweetFoundation.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "SweetFoundation"
   s.summary          = "Helpers and sugar for the Foundation framework"
-  s.version          = "2.0.0"
+  s.version          = "2.1.0"
   s.homepage         = "https://github.com/UseSweet/SweetFoundation"
   s.license          = 'MIT'
   s.author           = { "Bakken & Bæck" => "ios@bakkenbaeck.no" }

--- a/Tests/PredicateKeyPathTests.swift
+++ b/Tests/PredicateKeyPathTests.swift
@@ -545,7 +545,7 @@ class PredicateKeyPathTests: XCTestCase {
     
     func testInArrayWithDates() throws {
         let dateArray = [self.bbFoundingDate]
-        let inArrayPredicate = NSPredicate.isValue(for: \Company.dateFounded, in: dateArray)
+        let inArrayPredicate = NSPredicate.value(for: \Company.dateFounded, isIn: dateArray)
 
         let fetchedCompanies = try self.moc.fetchAll(Company.self,
                                                      sortDescriptors: self.sortCompaniesByName,
@@ -557,7 +557,7 @@ class PredicateKeyPathTests: XCTestCase {
     
     func testInSetWithDates() throws {
         let dateSet = Set([self.dunderMifflinFoundingDate])
-        let inSetPredicate = NSPredicate.isValue(for: \Company.dateFounded, in: dateSet)
+        let inSetPredicate = NSPredicate.value(for: \Company.dateFounded, isIn: dateSet)
         
         let fetchedCompanies = try self.moc.fetchAll(Company.self,
                                                      sortDescriptors: self.sortCompaniesByName,
@@ -569,8 +569,8 @@ class PredicateKeyPathTests: XCTestCase {
     
     func testInArrayWithIntegers() throws {
         let array: [Int16] = [ 28, 37 ]
-        let inArrayPredicate = NSPredicate.isValue(for: \Employee.age,
-                                                   in: array)
+        let inArrayPredicate = NSPredicate.value(for: \Employee.age,
+                                                 isIn: array)
         
         let fetchedEmployees = try self.moc.fetchAll(Employee.self,
                                                      sortDescriptors: self.sortEmployeesByName,
@@ -586,8 +586,8 @@ class PredicateKeyPathTests: XCTestCase {
     
     func testInSetWithIntegers() throws {
         let set: Set<Int16> = Set([ 99, 12 ])
-        let inSetPredicate = NSPredicate.isValue(for: \Employee.age,
-                                                 in: set)
+        let inSetPredicate = NSPredicate.value(for: \Employee.age,
+                                               isIn: set)
         
         let fetchedEmployees = try self.moc.fetchAll(Employee.self,
                                                      sortDescriptors: self.sortEmployeesByName,
@@ -603,8 +603,8 @@ class PredicateKeyPathTests: XCTestCase {
     
     func testInArrayWithStrings() throws {
         let array = [ "Pam", "Ellen" ]
-        let inArrayPredicate = NSPredicate.isValue(for: \Employee.name,
-                                                   in: array)
+        let inArrayPredicate = NSPredicate.value(for: \Employee.name,
+                                                 isIn: array)
         
         let fetchedEmployees = try self.moc.fetchAll(Employee.self,
                                                      sortDescriptors: self.sortEmployeesByName,
@@ -619,7 +619,7 @@ class PredicateKeyPathTests: XCTestCase {
     
     func testInSetWithStrings() throws {
         let set = Set([ "Daniël", "Michael" ])
-        let inSetPredicate = NSPredicate.isValue(for: \Employee.name, in: set)
+        let inSetPredicate = NSPredicate.value(for: \Employee.name, isIn: set)
         
         let fetchedEmployees = try self.moc.fetchAll(Employee.self,
                                                      sortDescriptors: self.sortEmployeesByName,
@@ -629,6 +629,108 @@ class PredicateKeyPathTests: XCTestCase {
         XCTAssertEqual(fetchedEmployees.map { $0.name }, [
             "Daniël",
             "Michael"
+        ])
+    }
+    
+    // MARK: - Not In
+    
+    func testNotInArrayWithDates() throws {
+        let dateArray = [self.bbFoundingDate]
+        let notInArrayPredicate = NSPredicate.value(for: \Company.dateFounded,
+                                                    isNotIn: dateArray)
+        
+        let fetchedCompanies = try self.moc.fetchAll(Company.self,
+                                                     sortDescriptors: self.sortCompaniesByName,
+                                                     predicate: notInArrayPredicate)
+        
+        XCTAssertEqual(fetchedCompanies.count, 1)
+        XCTAssertEqual(fetchedCompanies.map { $0.name }, [ "Dunder Mifflin" ])
+    }
+    
+    func testNotInSetWithDates() throws {
+        let dateSet = Set([self.dunderMifflinFoundingDate])
+        let notInSetPredicate = NSPredicate.value(for: \Company.dateFounded,
+                                                  isNotIn: dateSet)
+        
+        let fetchedCompanies = try self.moc.fetchAll(Company.self,
+                                                     sortDescriptors: self.sortCompaniesByName,
+                                                     predicate: notInSetPredicate)
+        
+        XCTAssertEqual(fetchedCompanies.count, 1)
+        XCTAssertEqual(fetchedCompanies.map { $0.name }, [ "Bakken & Bæck" ])
+    }
+    
+    func testNotInArrayWithIntegers() throws {
+        let array: [Int16] = [ 20, 21, 22, 23, 24, 25, 26, 27, 28, 29 ]
+        let notInArrayPredicate = NSPredicate.value(for: \Employee.age,
+                                                    isNotIn: array)
+        
+        let fetchedEmployees = try self.moc.fetchAll(Employee.self,
+                                                     sortDescriptors: self.sortEmployeesByName,
+                                                     predicate: notInArrayPredicate)
+        
+        XCTAssertEqual(fetchedEmployees.count, 7)
+        XCTAssertEqual(fetchedEmployees.map { $0.name }, [
+            "Dwight",
+            "Ellen",
+            "Johan",
+            "Michael",
+            "Ole Martin",
+            "Tobias",
+            "Wolfgang"
+        ])
+    }
+    
+    func testNotInSetWithIntegers() throws {
+        let set: Set<Int16> = Set([ 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39 ])
+        let notInSetPredicate = NSPredicate.value(for: \Employee.age,
+                                                  isNotIn: set)
+        
+        let fetchedEmployees = try self.moc.fetchAll(Employee.self,
+                                                     sortDescriptors: self.sortEmployeesByName,
+                                                     predicate: notInSetPredicate)
+        
+        XCTAssertEqual(fetchedEmployees.count, 4)
+        XCTAssertEqual(fetchedEmployees.map { $0.name }, [
+            "Dwight",
+            "Johan",
+            "Michael",
+            "Tobias"
+        ])
+    }
+    
+    
+    func testNotInArrayWithStrings() throws {
+        let array = [ "Bonn", "HQ" ]
+        let notInArrayPredicate = NSPredicate.value(for: \Office.name,
+                                                    isNotIn: array)
+        
+        let fetchedOffices = try self.moc.fetchAll(Office.self,
+                                                   sortDescriptors: self.sortOfficesByName,
+                                                   predicate: notInArrayPredicate)
+        
+        XCTAssertEqual(fetchedOffices.count, 3)
+        XCTAssertEqual(fetchedOffices.map { $0.name }, [
+            "Hamsterdance",
+            "London",
+            "Scranton"
+        ])
+    }
+    
+    func testNotInSetWithStrings() throws {
+        let set = Set([ "Scranton", "Hamsterdance", "Something totally different" ])
+        let notInSetPredicate = NSPredicate.value(for: \Office.name,
+                                                  isNotIn: set)
+        
+        let fetchedOffices = try self.moc.fetchAll(Office.self,
+                                                   sortDescriptors: self.sortOfficesByName,
+                                                   predicate: notInSetPredicate)
+        
+        XCTAssertEqual(fetchedOffices.count, 3)
+        XCTAssertEqual(fetchedOffices.map { $0.name }, [
+            "Bonn",
+            "HQ",
+            "London"
         ])
     }
     

--- a/Tests/PredicateKeyPathTests.swift
+++ b/Tests/PredicateKeyPathTests.swift
@@ -541,6 +541,97 @@ class PredicateKeyPathTests: XCTestCase {
         ])
     }
     
+    // MARK: - In
+    
+    func testInArrayWithDates() throws {
+        let dateArray = [self.bbFoundingDate]
+        let inArrayPredicate = NSPredicate.isValue(for: \Company.dateFounded, in: dateArray)
+
+        let fetchedCompanies = try self.moc.fetchAll(Company.self,
+                                                     sortDescriptors: self.sortCompaniesByName,
+                                                     predicate: inArrayPredicate)
+        
+        XCTAssertEqual(fetchedCompanies.count, 1)
+        XCTAssertEqual(fetchedCompanies.map { $0.name }, [ "Bakken & Bæck" ])
+    }
+    
+    func testInSetWithDates() throws {
+        let dateSet = Set([self.dunderMifflinFoundingDate])
+        let inSetPredicate = NSPredicate.isValue(for: \Company.dateFounded, in: dateSet)
+        
+        let fetchedCompanies = try self.moc.fetchAll(Company.self,
+                                                     sortDescriptors: self.sortCompaniesByName,
+                                                     predicate: inSetPredicate)
+        
+        XCTAssertEqual(fetchedCompanies.count, 1)
+        XCTAssertEqual(fetchedCompanies.map { $0.name }, [ "Dunder Mifflin" ])
+    }
+    
+    func testInArrayWithIntegers() throws {
+        let array: [Int16] = [ 28, 37 ]
+        let inArrayPredicate = NSPredicate.isValue(for: \Employee.age,
+                                                   in: array)
+        
+        let fetchedEmployees = try self.moc.fetchAll(Employee.self,
+                                                     sortDescriptors: self.sortEmployeesByName,
+                                                     predicate: inArrayPredicate)
+        
+        XCTAssertEqual(fetchedEmployees.count, 3)
+        XCTAssertEqual(fetchedEmployees.map { $0.name }, [
+            "Daniël",
+            "Ellen",
+            "Tristan"
+        ])
+    }
+    
+    func testInSetWithIntegers() throws {
+        let set: Set<Int16> = Set([ 99, 12 ])
+        let inSetPredicate = NSPredicate.isValue(for: \Employee.age,
+                                                 in: set)
+        
+        let fetchedEmployees = try self.moc.fetchAll(Employee.self,
+                                                     sortDescriptors: self.sortEmployeesByName,
+                                                     predicate: inSetPredicate)
+        
+        XCTAssertEqual(fetchedEmployees.count, 2)
+        XCTAssertEqual(fetchedEmployees.map { $0.name }, [
+            "Johan",
+            "Tobias"
+        ])
+    }
+    
+    
+    func testInArrayWithStrings() throws {
+        let array = [ "Pam", "Ellen" ]
+        let inArrayPredicate = NSPredicate.isValue(for: \Employee.name,
+                                                   in: array)
+        
+        let fetchedEmployees = try self.moc.fetchAll(Employee.self,
+                                                     sortDescriptors: self.sortEmployeesByName,
+                                                     predicate: inArrayPredicate)
+        
+        XCTAssertEqual(fetchedEmployees.count, 2)
+        XCTAssertEqual(fetchedEmployees.map { $0.name }, [
+            "Ellen",
+            "Pam"
+        ])
+    }
+    
+    func testInSetWithStrings() throws {
+        let set = Set([ "Daniël", "Michael" ])
+        let inSetPredicate = NSPredicate.isValue(for: \Employee.name, in: set)
+        
+        let fetchedEmployees = try self.moc.fetchAll(Employee.self,
+                                                     sortDescriptors: self.sortEmployeesByName,
+                                                     predicate: inSetPredicate)
+        
+        XCTAssertEqual(fetchedEmployees.count, 2)
+        XCTAssertEqual(fetchedEmployees.map { $0.name }, [
+            "Daniël",
+            "Michael"
+        ])
+    }
+    
     // MARK: - Between
     
     func testBetweenWithDates() throws {

--- a/Tests/PredicateKeyPathTests.swift
+++ b/Tests/PredicateKeyPathTests.swift
@@ -302,7 +302,7 @@ class PredicateKeyPathTests: XCTestCase {
         
         let officeResult = try self.moc.fetchAll(Office.self,
                                                  sortDescriptors: self.sortOfficesByName,
-                                            predicate: notCompanyPredicate)
+                                                 predicate: notCompanyPredicate)
         
         XCTAssertEqual(officeResult.count, 4)
         XCTAssertEqual(officeResult.map { $0.name }, [
@@ -317,8 +317,8 @@ class PredicateKeyPathTests: XCTestCase {
     
     func testGreaterThanPredicateWithDouble() throws {
         let longOver0point2Predicate = NSPredicate(keyPath: \Office.longitude,
-                                             operatorType: .greaterThan,
-                                             value: 0.2)
+                                                   operatorType: .greaterThan,
+                                                   value: 0.2)
         
         let fetchedOffices = try self.moc.fetchAll(Office.self,
                                                    sortDescriptors: self.sortOfficesByName,
@@ -563,9 +563,9 @@ class PredicateKeyPathTests: XCTestCase {
         
         XCTAssertEqual(fetchedEmployees.count, 3)
         XCTAssertEqual(fetchedEmployees.map { $0.name }, [
-          "Dwight",
-          "Ellen",
-          "Michael"
+            "Dwight",
+            "Ellen",
+            "Michael"
         ])
     }
     


### PR DESCRIPTION
Ran straight into this one when I finally tried to use this in production. This will allow us to fetch items where the value at the given keypath matches an array or set of items handed in. 

Also fixed some alignment oopses in the tests 🙀