### PR TITLE
Swift 5 Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
     build-and-test:
         macos:
-            xcode: "10.0.0"
+            xcode: "10.2.0"
         # Use custom shell per https://circleci.com/docs/2.0/testing-ios/#using-custom-versions-of-cocoapods-and-other-ruby-gems
         shell: /bin/bash --login -o pipefail
         steps:

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -293,13 +293,13 @@
 			attributes = {
 				CLASSPREFIX = "";
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					14E527AC1E9294F3009B22FD = {
 						CreatedOnToolsVersion = 8.3;
 						DevelopmentTeam = 29X3GG489T;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					9F2018C21DFFF14E000FF81F = {
@@ -311,14 +311,14 @@
 					9F63ADA91DA584F600A9FEEF = {
 						CreatedOnToolsVersion = 8.1;
 						DevelopmentTeam = 29X3GG489T;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 				};
 			};
 			buildConfigurationList = 146D728E1AB782920058798C /* Build configuration list for PBXProject "Demo" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -419,6 +419,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -472,6 +473,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -529,7 +531,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -547,7 +549,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.bakkenbaeck.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -640,7 +642,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -671,7 +673,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Demo.xcodeproj/xcshareddata/xcschemes/SweetFoundation.xcscheme
+++ b/Demo.xcodeproj/xcshareddata/xcschemes/SweetFoundation.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demo.xcodeproj/xcshareddata/xcschemes/SweetFoundationMac.xcscheme
+++ b/Demo.xcodeproj/xcshareddata/xcschemes/SweetFoundationMac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demo.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Demo.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Collection+Sweetness.swift
+++ b/Sources/Collection+Sweetness.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension Collection {
-    public func element(at index: Index) -> Iterator.Element? {
+    func element(at index: Index) -> Iterator.Element? {
         return indices.contains(index) ? self[index] : nil
     }
 }

--- a/Sources/Data+Sweetness.swift
+++ b/Sources/Data+Sweetness.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension Data {
-    public func base64EncodedStringWithoutPadding() -> String {
+    func base64EncodedStringWithoutPadding() -> String {
         let base64 = self.base64EncodedString()
 
         if base64.hasSuffix("==") {
@@ -13,7 +13,7 @@ public extension Data {
         return base64
     }
 
-    public func hexadecimalString() -> String {
+    func hexadecimalString() -> String {
         var hexString = ""
         for byte in [UInt8](self) {
             hexString += String(format: "%02lx", byte)

--- a/Sources/DispatchQueue+Sweetness.swift
+++ b/Sources/DispatchQueue+Sweetness.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension DispatchQueue {
-    public func asyncAfter(seconds: Double, execute block: @escaping () -> Void) {
+    func asyncAfter(seconds: Double, execute block: @escaping () -> Void) {
         let deadline: DispatchTime = DispatchTime.now() + Double(Int64(seconds * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
         self.asyncAfter(deadline: deadline, execute: block)
     }

--- a/Sources/String+Sweetness.swift
+++ b/Sources/String+Sweetness.swift
@@ -9,7 +9,7 @@ public extension Range where Bound: _StringIndex {
     ///
     /// - Parameter string: string where ranges will be applied. Necessary to ensure that multi-byte code-points are treated properly.
     /// - Returns: the NSRange representation of a Range<String.Index> for the given string.
-    public func nsRange(on string: String) -> NSRange {
+    func nsRange(on string: String) -> NSRange {
         guard let lowerBound = self.lowerBound as? String.Index, let upperBound = self.upperBound as? String.Index else {
             fatalError("Could not cast range bounds as String.Index.")
         }
@@ -23,13 +23,13 @@ public extension Range where Bound: _StringIndex {
 }
 
 public extension NSRange {
-    public func range(on string: NSString) -> Range<String.Index>? {
+    func range(on string: NSString) -> Range<String.Index>? {
         let substring = string.substring(with: self)
 
         return (string as String).range(of: substring)
     }
 
-    public func range(on string: String) -> Range<String.Index>? {
+    func range(on string: String) -> Range<String.Index>? {
         guard let substring = string.substring(with: self) else { fatalError("Range out of bounds for string.") }
 
         return (string).range(of: substring)
@@ -37,13 +37,13 @@ public extension NSRange {
 }
 
 public extension String {
-    public var wholeRange: Range<String.Index> {
+    var wholeRange: Range<String.Index> {
         // If string is empty, self.range(of:) is nil.
         // So we return a {0,0} range instead.
         return self.range(of: self) ?? Range<String.Index>(NSRange(location: 0, length: 0), in: self)!
     }
 
-    public var paddedForBase64: String {
+    var paddedForBase64: String {
         let length = self.decomposedStringWithCanonicalMapping.count
         let paddingString = "="
         let paddingLength = length % 4
@@ -57,13 +57,13 @@ public extension String {
         }
     }
 
-    public func substring(with nsRange: NSRange) -> Substring? {
+    func substring(with nsRange: NSRange) -> Substring? {
         guard let range = nsRange.range(on: self as NSString) else { return nil }
 
         return self[range]
     }
 
-    public func nsRange(of string: String) -> NSRange {
+    func nsRange(of string: String) -> NSRange {
         return (self as NSString).range(of: string)
     }
 }

--- a/SweetFoundation.podspec
+++ b/SweetFoundation.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "SweetFoundation"
   s.summary          = "Helpers and sugar for the Foundation framework"
-  s.version          = "2.1.0"
+  s.version          = "3.0.0"
   s.homepage         = "https://github.com/UseSweet/SweetFoundation"
   s.license          = 'MIT'
   s.author           = { "Bakken & Bæck" => "ios@bakkenbaeck.no" }


### PR DESCRIPTION
Mostly just deleting `public` from public extensions since that's now redundant. 

Note: Bumping to 3.0.0 since this would be a breaking change for anyone still on Swift 4. 